### PR TITLE
Refactor hardcoded from and to dates to use yesterday's date

### DIFF
--- a/pepys_timeline/static/js/src/pepys.js
+++ b/pepys_timeline/static/js/src/pepys.js
@@ -1,6 +1,9 @@
 moment.locale("en");
 
-const DATETIME_FORMAT = "YYYY-MM-DD HH:mm:ss";
+const DATE_FORMATS = {
+  visavail: "YYYY-MM-DD HH:mm:ss",
+  metadata: "YYYY-MM-DD"
+}
 
 let generatedCharts = false;
 let charts;
@@ -85,8 +88,13 @@ function fetchSerialsMeta() {
 
     const url = new URL(window.location + 'dashboard_metadata');
     const queryParams = new URLSearchParams();
-    queryParams.set('from_date', '2021-01-05');
-    queryParams.set('to_date', '2021-01-05');
+
+    const today = new Date();
+    const yesterday = new Date();
+    yesterday.setDate(today.getDate() - 1);
+
+    queryParams.set('from_date', moment(yesterday).format(DATE_FORMATS.metadata));
+    queryParams.set('to_date', moment(yesterday).format(DATE_FORMATS.metadata));
     url.search = queryParams.toString();
 
     fetch(url)
@@ -178,9 +186,9 @@ function transformParticipant(participant, serial) {
         && s.resp_serial_id === participant.serial_name
     )
     let periods = participantStats.map(s => ([
-            moment(s.resp_start_time).format(DATETIME_FORMAT),
+            moment(s.resp_start_time).format(DATE_FORMATS.visavail),
             Number(s.resp_range_type === "C"),
-            moment(s.resp_end_time).format(DATETIME_FORMAT),
+            moment(s.resp_end_time).format(DATE_FORMATS.visavail),
         ]));
     participant.coverage = periods;
 


### PR DESCRIPTION
This PR replaces hardcoded `from_date` and `to_date` params for metadata query in favour of using yesterday's date for both values.